### PR TITLE
Replacing console log with Pino Logger

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
-import { Logger } from 'nestjs-pino';
+import { Logger, PinoLogger } from 'nestjs-pino';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
@@ -32,8 +32,10 @@ async function bootstrap() {
   SwaggerModule.setup('/', app, document);
 
   const port = process.env.PORT || 8191;
+  const logger = new PinoLogger({});
+  logger.setContext('RedisCatApplication');
   await app.listen(port, () =>
-    console.log(`Application started on port ${port}`),
+    logger.info(`Application started on port ${port}`),
   );
 }
 bootstrap();


### PR DESCRIPTION
Application bootstrapping port message replaced from the console.log into the Pino info level

![Screenshot from 2022-10-22 14-06-29](https://user-images.githubusercontent.com/45075536/197330027-d2d6eaed-5fed-4f64-916f-d7889079a6f2.png)
